### PR TITLE
Only show up to 4 instance paths

### DIFF
--- a/src/main/kotlin/com/pistacium/modcheck/ModCheckFrameFormExt.kt
+++ b/src/main/kotlin/com/pistacium/modcheck/ModCheckFrameFormExt.kt
@@ -62,12 +62,15 @@ class ModCheckFrameFormExt : ModCheckFrameForm() {
                 selectDirs = instanceDirectories
                 var parentDir = ""
                 val stringBuilder = StringBuilder()
-                for (selectDir in instanceDirectories) {
+                for (selectDir in instanceDirectories.slice(IntRange(0, instanceDirectories.size.coerceAtMost(4) - 1))) {
                     stringBuilder.append(if (parentDir.isEmpty()) selectDir.path else selectDir.path.replace(parentDir, "")).append(", ")
                     parentDir = selectDir.parent
                 }
+                if (instanceDirectories.size > 4) {
+                    stringBuilder.append("and " + (instanceDirectories.size - 4) + " more...")
+                }
                 selectedDirLabel!!.text =
-                    "<html>Selected Instances : <br>" + stringBuilder.substring(0, stringBuilder.length - (if (stringBuilder.isNotEmpty()) 2 else 0)) + "</html>"
+                    "<html>Selected Instances : <br>" + stringBuilder.removeSuffix(", ") + "</html>"
             }
             ModCheckUtils.writeConfig(instanceDirectories[0].parentFile.toPath())
         }


### PR DESCRIPTION
Selecting 12 instances looks like this (components get cut off due to the big JLabel stretch):
![image](https://github.com/tildejustin/modcheck/assets/59705125/1cf13a1e-f223-4733-b629-17e9cb016194)

With PR:
![image](https://github.com/tildejustin/modcheck/assets/59705125/c35c3dc4-8dc6-4813-855d-1cbb2d8c5ff4)

Kotlin funny