### PR TITLE
Better folder resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.redlime"
-version = "3.0.1"
+version = "3.0.2"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
logic was written by me, kotlin code was written by chatgpt, so take it with caution, though i tested that it should work as expected

this attempts to improve logic for folder path handling in general, two specific issues before:
- selecting a `mods` folder itself didn't work
- selecting an instance folder from an instance that was just created in mmc / prism and wasn't launched yet didn't work