### PR TITLE
More adaptive defaults for modcheck CLI

### DIFF
--- a/src/main/kotlin/com/pistacium/modcheck/MmcPackJson.kt
+++ b/src/main/kotlin/com/pistacium/modcheck/MmcPackJson.kt
@@ -1,0 +1,9 @@
+package com.pistacium.modcheck
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+class MmcPackJson(val components: Array<Component>, val formatVersion: Int) {
+    @Serializable
+    class Component(val uid: String, val version: String)
+}

--- a/src/main/kotlin/com/pistacium/modcheck/ModCheck.kt
+++ b/src/main/kotlin/com/pistacium/modcheck/ModCheck.kt
@@ -112,6 +112,20 @@ object ModCheck {
         }
     }
 
+    private fun readPrismVersion(): String? {
+        return try {
+            System.getenv("INST_DIR")
+                ?.takeIf { isValidPath(it) }
+                ?.let { Paths.get(it).resolve("mmc-pack.json") }
+                ?.let { String(Files.readAllBytes(it), Charsets.UTF_8) }
+                ?.let { ModCheckUtils.json.decodeFromString<MmcPackJson>(it) }
+                ?.components?.first { it.uid == "net.minecraft" }?.version
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+
     private fun handleCliMode(args: Array<String>) {
         // Load mod list for CLI
         val mods = ModCheckUtils.json.decodeFromString<Meta>(
@@ -121,9 +135,9 @@ object ModCheck {
 
         // Defaults
         var category = "rsg"
-        var os = ModCheckUtils.currentOS()
+        val os = ModCheckUtils.currentOS()
         var accessibility = false
-        var version = "1.16.1"
+        var version = readPrismVersion() ?: "1.16.1"
         var path: String? = System.getenv("INST_DIR")
         var function: String? = null
         // Adjust default if instance name contains "ssg"

--- a/src/main/kotlin/com/pistacium/modcheck/ModCheck.kt
+++ b/src/main/kotlin/com/pistacium/modcheck/ModCheck.kt
@@ -126,7 +126,10 @@ object ModCheck {
         var version = "1.16.1"
         var path: String? = System.getenv("INST_DIR")
         var function: String? = null
-
+        // Adjust default if instance name contains "ssg"
+        if (System.getenv("INST_NAME")?.contains(Regex("(?i)(?<![a-z])ssg(?![a-z])")) == true) {
+            category = "ssg"
+        }
 
         // Parsing args
         var i = 0

--- a/src/main/kotlin/com/pistacium/modcheck/ModCheck.kt
+++ b/src/main/kotlin/com/pistacium/modcheck/ModCheck.kt
@@ -124,7 +124,7 @@ object ModCheck {
         var os = ModCheckUtils.currentOS()
         var accessibility = false
         var version = "1.16.1"
-        var path: String? = null
+        var path: String? = System.getenv("INST_DIR")
         var function: String? = null
 
 


### PR DESCRIPTION
- Use environment variable INST_DIR directly if available, 100% resistant against spaces in paths
- Change default category to ssg if instance name contains "ssg"
- Get version from mmc-pack.json if possible